### PR TITLE
Fix 34

### DIFF
--- a/src/frame.py
+++ b/src/frame.py
@@ -144,6 +144,9 @@ class Coord(object):
         return ((self.lon.deg, self.lat.deg) <
                 (other.lon.deg, other.lat.deg))
     
+    def __neg__(self):
+          return  Coord(self.frame,-self.lon, -self.lat,self.epoch)
+    
     def __gt__(self, other):
         return not self.__lt__(other)
 

--- a/src/scanmode/maps.py
+++ b/src/scanmode/maps.py
@@ -238,7 +238,7 @@ class RasterMapScan(MapScan):
             self.dimension_x = len(self.offset_x)
             self.dimension_y = len(self.offset_y)
         else:
-            super(RasterMapScan, self)._get_spacing()
+            super(RasterMapScan, self)._get_spacing(receiver, frequency)
 
     def _get_offsets(self):
         """

--- a/src/scanmode/nodding.py
+++ b/src/scanmode/nodding.py
@@ -13,7 +13,6 @@ class NoddingScan(ScanMode):
         self.sequence = sequence
         self.unit_subscans = sum(el[0] for el in self.sequence)
         self.frame = frame.NULL
-
     def _do_scan(self, _target, _receiver, _frequency):
         if not _target.offset_coord.is_null():
             if not _target.offset_coord.frame == frame.HOR:
@@ -25,9 +24,10 @@ class NoddingScan(ScanMode):
         _subscans = []
         for element in self.sequence:
             if element[1] == "a":
-                offset = offset_a
+                offset = -offset_a #the sign must be opposite to the feed displacement  
             else:
-                offset = offset_b
+                offset = -offset_b #the sign must be opposite to the feed displacement
+            self.offset=offset
             ss = subscan.get_sidereal(_target,
                                       offset,
                                       self.duration,

--- a/test/test_nodding.py
+++ b/test/test_nodding.py
@@ -1,0 +1,32 @@
+#coding=utf-8
+
+import unittest2 as unittest
+
+from basie.frame import EQ, HOR
+from astropy.units import MHz
+from basie.radiotelescopes import SRT
+from basie.scanmode import subscan, maps,nodding
+from basie.valid_angles import VAngle
+from basie.receiver import Receiver
+from basie import frame, target_parser
+
+class TestNoddingScan(unittest.TestCase):
+
+   def setUp(self):
+      feed_a=3
+      feed_b=0
+      self._recv = Receiver("TEST", 0, 100,
+                             [[0.0, 100.0], [5.0, 5.0]],
+                             nfeed = 7,
+                             npols = 2,
+                             has_derotator = True)
+      seq=[(2,'a',0),(2,'a',1),(2,'b',0),(2,'b',1)]
+      self._nodding=nodding.NoddingScan([feed_a,feed_b],30,seq)
+      self._offset=self._recv.feed_offsets[feed_b]
+      LINE = "3C386 otfmap1 TP EQ 10.0d 1:00:00.0h"
+      self.SCANTYPE, self.BACKEND, self.TARGET = target_parser._parse_target_line(LINE)
+   def test_nodding(self):
+      self._nodding._do_scan(self.TARGET,self._recv,20.000)
+      self.assertEqual(self._nodding.offset,-self._offset)
+    
+    


### PR DESCRIPTION
The offset for nodding scans must have the opposite sign of the feed displacement. 
Overloaded operator neg for object Coord to allow the change of sign. 
Implemented change of sign
Bug in the rasterScan maps: not enough parameters in the super call. Patched. 