### PR TITLE
Python 3 compatibility, a lot of it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - "3.5"
   - "2.7"
   - "2.6"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 BTrees>=4.1.4
 argparse>=1.2.1
 numpy>=1.6.1
-astropy==1.1.2
-configobj
+astropy>=1.1.2
+# configobj
 persistent>=4.1.1
 pickleshare>=0.5
 transaction>=1.4.4
@@ -12,3 +12,4 @@ ZConfig>=3.0.4
 ZODB>=4.2.0
 zodbpickle>=0.6.0
 zope.interface>=4.1.2
+future

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -186,7 +186,10 @@ You will find the doc under doc/html/
 @license: gpl v3.0
 @contact: bartolini@ira.inaf.it
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import str
 VERSION = "0.6.5"
 NURAGHE_TAG = "nuraghe-0.6"
 ESCS_TAG = "escs-0.6"
@@ -220,7 +223,7 @@ def cmd_line():
     #parsing command line arguments
     ns = parser.parse_args()
     if ns.show_version:
-        print "basie version: %s" % (VERSION,)
+        print("basie version: %s" % (VERSION,))
         sys.exit()
     #setting logger level and format
     if ns.debug:
@@ -231,12 +234,12 @@ def cmd_line():
     logger = logging.getLogger("basie")
     #if debugging show command line parameters
     logger.debug("Running with options:")
-    for k,v in vars(ns).iteritems():
+    for k,v in vars(ns).items():
         logger.debug("\t%s:\t%s" % (k, str(v),))
 
     #imports are here as logging has already been configured
-    import schedule, rich_validator, utils, target_parser, receiver
-    from radiotelescopes import radiotelescopes
+    from . import schedule, rich_validator, utils, target_parser, receiver
+    from .radiotelescopes import radiotelescopes
 
     try:
         if ns.get_templates:
@@ -282,7 +285,7 @@ def cmd_line():
             _schedule.set_base_dir(dst_directory)
             _schedule._write_schedule_files()
         logger.info('closing gently')
-    except Exception, e:
+    except Exception as e:
         logger.info("exiting with error")
         logger.error(str(e))
         if ns.debug:

--- a/src/angle_parser.py
+++ b/src/angle_parser.py
@@ -1,12 +1,14 @@
 #coding=utf-8
+from __future__ import absolute_import
+from builtins import str
 import re
 import logging
 logger = logging.getLogger(__name__)
-import validate
+from astropy.extern.configobj import validate
 
 from astropy import units as u
 
-from valid_angles import VAngle
+from .valid_angles import VAngle
 
 dec_angle_pattern = "^[+-]?\d+(.\d+)?d$"
 dec_angle_re = re.compile(dec_angle_pattern)

--- a/src/backend.py
+++ b/src/backend.py
@@ -18,12 +18,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+from builtins import range
 import logging
 logger=logging.getLogger(__name__)
 
 from persistent import Persistent
 
-from errors import *
+from .errors import *
 
 
 class Backend(Persistent):

--- a/src/frame.py
+++ b/src/frame.py
@@ -31,6 +31,7 @@ exported constants:
     - axes
 """
 
+from builtins import object
 import logging
 logger = logging.getLogger(__name__)
 import copy

--- a/src/layout.py
+++ b/src/layout.py
@@ -18,11 +18,12 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
 __all__ = ['COMMON_CONSTANTS', 'CROSS_CONSTANTS', 'get_wcs_params',
             'get_layout_params']
 
-import frame
-import scanmode
+from . import frame
+from . import scanmode
 
 COMMON_CONSTANTS = dict(
                        WOBUSED = 0,

--- a/src/procedures.py
+++ b/src/procedures.py
@@ -18,11 +18,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+from builtins import str
+from builtins import object
 import re
 import copy
 import functools
 
-from errors import *
+from .errors import *
 
 TSYS_WAIT_TIME = 2
 """

--- a/src/radiotelescopes.py
+++ b/src/radiotelescopes.py
@@ -9,6 +9,7 @@ Each radiotelescope is represented a dictionary containing:
     - acc_scale_factor: scale factor used to overstimate maximum acceleration
     - receivers: receivers as defined in L{receiver} module
 """
+from __future__ import absolute_import
 
 __all__ = ["MED", "SRT", "NOTO", "radiotelescopes"]
 
@@ -16,8 +17,8 @@ import math
 from persistent import Persistent
 from astropy import units as u
 
-from receiver import Receiver
-from valid_angles import VAngle
+from .receiver import Receiver
+from .valid_angles import VAngle
 
 class Radiotelescope(Persistent):
     def __init__(self, name=""):

--- a/src/receiver.py
+++ b/src/receiver.py
@@ -18,6 +18,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import
+from builtins import range
 import logging
 logger = logging.getLogger(__name__)
 
@@ -25,10 +27,10 @@ from numpy import interp
 from astropy import units as u 
 from persistent import Persistent
 
-from valid_angles import VAngle
-from errors import *
+from .valid_angles import VAngle
+from .errors import *
 
-from frame import Coord, HOR
+from .frame import Coord, HOR
 
 class Receiver(Persistent):
     """

--- a/src/rich_validator.py
+++ b/src/rich_validator.py
@@ -24,22 +24,25 @@ arguments from configuration file.
 In particular it adds new possible instances to be used in the .ini schemas
 files.
 """
+from __future__ import absolute_import
 
+from builtins import str
 import logging
 logger = logging.getLogger(__name__)
 
 import os
 import re
 import datetime
-import configobj
-import validate as v
+# import configobj
+from astropy.extern.configobj import validate as v
+from astropy.extern.configobj import configobj
 
-import angle_parser
-import frame
-from scanmode import *
-import utils
-import velocity
-from backend import BackendFactory
+from . import angle_parser
+from . import frame
+from .scanmode import *
+from . import utils
+from . import velocity
+from .backend import BackendFactory
 
 valid_list_element = re.compile("\[.+\]|[^\s,]+")
 """
@@ -121,7 +124,7 @@ def check_skydip_scan(value):
 def check_otf_map(value):
     if not isinstance(value, list):
         raise v.ValidateError("expected list, found  %s" % (value,))
-    _frame = check_frame(value[0]) 
+    _frame = check_frame(value[0])
     scan_axis = value[1].upper()
     logger.debug("scan axis: %s" % (scan_axis,))
     if not scan_axis in frame.axes:
@@ -151,7 +154,7 @@ def check_otf_map(value):
 def check_raster_map(value):
     if not isinstance(value, list):
         raise v.ValidateError("expected list, found  %s" % (value,))
-    _frame = check_frame(value[0]) 
+    _frame = check_frame(value[0])
     scan_axis = value[1].upper()
     if not scan_axis in frame.axes:
         raise v.ValidateError("not a valid axis: %s" % (scan_axis,))
@@ -224,7 +227,7 @@ def check_onoff(value):
     if not isinstance(value, list):
         raise v.ValidateError("expected list, found  %s" % (value,))
     duration = v.is_float(value[0], min=0)
-    offset_frame = check_frame(value[1]) 
+    offset_frame = check_frame(value[1])
     offset_lon = angle_parser.check_angle(value[2])
     offset_lat = angle_parser.check_angle(value[3])
     sequence = check_onoff_sequence(value[4][1:-1]) #strip [ and ]
@@ -236,7 +239,9 @@ def check_scantype(value):
         #this is aginst a bug in the validate module
         #AKA a brutal workaround
         value = ' '.join(value)
+
     value = string2list(value)
+
     logger.debug("got value: %s" % (value,))
     scantype = value[0].upper()
     if scantype == "CROSS":
@@ -304,21 +309,21 @@ rich_validator = v.Validator(valid_types)
 
 def validate(filename, specfilename):#, error_stream=sys.stderr):
     conf = configobj.ConfigObj(filename, configspec=specfilename)
-    res = conf.validate(rich_validator, preserve_errors=True)
+    res = conf.validate(rich_validator, preserve_errors=False)
     if not res:
         flat_errs = configobj.flatten_errors(conf, res)
         for _, var, ex in flat_errs:
             logger.error("%s : %s\n" % (var, str(ex)))
         raise v.ValidateError("Could not validate %s vs %s" % (filename, specfilename))
-    for k,v in conf["backends"].iteritems():
+    for k,v in conf["backends"].items():
         v["name"] = k
         conf["backends"][k] = BackendFactory(v)
-    for k,v in conf["scantypes"].iteritems():
+    for k,v in conf["scantypes"].items():
         if isinstance(v, tuple):
             logger.info(("exploding scanmode {0} in 2 separate scans: {0}_lon" + \
                         " and {0}_lat").format(k,))
             conf["scantypes"].pop(k)
-            if ((k + "_lon" in conf["scantypes"]) or 
+            if ((k + "_lon" in conf["scantypes"]) or
                 (k + "_lat" in conf["scantypes"])):
                raise ScheduleError("Cannot explode scan %s in separate subscans" % (k,))
             conf["scantypes"][k + "_lon"] = v[0]

--- a/src/scan.py
+++ b/src/scan.py
@@ -1,12 +1,14 @@
+from __future__ import absolute_import
 #coding utf-8
 
+from builtins import range
 import logging
 logger = logging.getLogger(__name__)
 
 from persistent import Persistent
 from astropy import units as u
 
-import frame
+from . import frame
 import copy
 
 class Scan(Persistent):
@@ -52,7 +54,7 @@ class Scan(Persistent):
                                               self.receiver, 
                                               self.frequency)
         counter = 0
-        for rep in xrange(self.repetitions):
+        for rep in range(self.repetitions):
             for sn, ss in enumerate(base_subscans):
                 #logger.debug("REP: %d SUBSCAN: %d" % (rep, sn))
                 #subscan_number = rep * self.scanmode.unit_subscans + sn

--- a/src/scanmode/__init__.py
+++ b/src/scanmode/__init__.py
@@ -1,9 +1,10 @@
-from scanmode import ScanMode
-from cross import CrossScan, PointScan
-from maps import MapScan, OTFMapScan, RasterMapScan
-from nodding import NoddingScan
-from onoff import OnOffScan
-from skydip import SkydipScan
+from __future__ import absolute_import
+from .scanmode import ScanMode
+from .cross import CrossScan, PointScan
+from .maps import MapScan, OTFMapScan, RasterMapScan
+from .nodding import NoddingScan
+from .onoff import OnOffScan
+from .skydip import SkydipScan
 
 START_POINTS = ('TL', 'TR', 'BL', 'BR')
 """

--- a/src/scanmode/cross.py
+++ b/src/scanmode/cross.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import logging
 logger = logging.getLogger(__name__)
 
-from scanmode import ScanMode
-import subscan
+from .scanmode import ScanMode
+from . import subscan
 from .. import procedures
 from basie.valid_angles import VAngle
 

--- a/src/scanmode/maps.py
+++ b/src/scanmode/maps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from builtins import range
 import logging
 logger = logging.getLogger(__name__)
 import itertools
@@ -7,9 +9,9 @@ from basie import utils, frame
 from basie.valid_angles import VAngle
 from basie.errors import *
 
-from scanmode import ScanMode
+from .scanmode import ScanMode
 from ..frame import Coord
-import subscan
+from . import subscan
 
 class MapScan(ScanMode):
     """
@@ -130,7 +132,7 @@ class OTFMapScan(MapScan):
                     _directions = ("INC", "DEC")
                 else:
                     _directions = ("DEC", "INC")
-            for _offset, _direction in itertools.izip(_offsets,
+            for _offset, _direction in zip(_offsets,
                                                       itertools.cycle(_directions)):
                 logger.debug("OTF: %d offset %s direction %s" % (self.ID,
                                                                  _offset,
@@ -159,7 +161,7 @@ class OTFMapScan(MapScan):
                 _directions = ("INC", "DEC")
             else:
                 _directions = ("DEC", "INC")
-            for _offset, _direction in itertools.izip(_offsets,
+            for _offset, _direction in zip(_offsets,
                                                       itertools.cycle(_directions)):
                 logger.debug("OTF: %d offset %s direction %s" % (self.ID,
                                                                  _offset,

--- a/src/scanmode/nodding.py
+++ b/src/scanmode/nodding.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
 
-from scanmode import ScanMode
+from builtins import range
+from .scanmode import ScanMode
 from . import subscan
 from .. import frame
 from ..errors import ScanError

--- a/src/scanmode/onoff.py
+++ b/src/scanmode/onoff.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
+from builtins import range
 from basie.valid_angles import VAngle
 from basie.errors import ScheduleError
 
-from scanmode import ScanMode
+from .scanmode import ScanMode
 from ..frame import NULL, Coord
-import subscan
+from . import subscan
 
 class OnOffScan(ScanMode):
     def __init__(self, duration, offset_lon, offset_lat, offset_frame, sequence):

--- a/src/scanmode/scanmode.py
+++ b/src/scanmode/scanmode.py
@@ -50,6 +50,8 @@ class ScanMode(Persistent):
         return self.ID < other.ID
 
     def __eq__(self, other):
+        if not hasattr(other, 'ID'):
+            return False
         return self.ID == other.ID
 
     def __str__(self):
@@ -68,9 +70,9 @@ class ScanMode(Persistent):
         logger.debug("scheduling %s on target %s" % (self.name, _target.label))
         try:
             return self._do_scan(_target, _receiver, _frequency)
-        except Exception, e:
+        except Exception as e:
             message = "Scan %s on target %s\n\t%s" %\
-                    (self.name, 
+                    (self.name,
                      _target.label,
                      e.message)
             raise ScanError(message)

--- a/src/scanmode/skydip.py
+++ b/src/scanmode/skydip.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import logging
 logger = logging.getLogger(__name__)
 
-from scanmode import ScanMode
-import subscan
+from .scanmode import ScanMode
+from . import subscan
 from .. import procedures
 from basie.valid_angles import VAngle
 from basie.frame import NULL_COORD, Coord, HOR

--- a/src/scanmode/subscan.py
+++ b/src/scanmode/subscan.py
@@ -36,6 +36,8 @@ together with their associated Tsys sidereal subscan.
     - get_sid_couple_subscan
 """
 
+from past.builtins import cmp
+from builtins import str
 import logging
 logger = logging.getLogger(__name__)
 import copy

--- a/src/target.py
+++ b/src/target.py
@@ -24,16 +24,17 @@ exposed classes:
     - Target 
     - ObservedTarget
 """
+from __future__ import absolute_import
 
 import logging
 logger = logging.getLogger(__name__)
 
 from persistent import Persistent
 
-from valid_angles import VAngle
+from .valid_angles import VAngle
 from . import frame as fr
-from velocity import ZERO_VELOCITY
-from errors import *
+from .velocity import ZERO_VELOCITY
+from .errors import *
 
 class Target(Persistent):
     def __init__(self, label, coord, velocity = ZERO_VELOCITY):

--- a/src/target_parser.py
+++ b/src/target_parser.py
@@ -1,16 +1,17 @@
 #coding=utf-8
 
+from __future__ import absolute_import
 import re
 import logging
 logger = logging.getLogger(__name__)
 
-import valid_angles
-from valid_angles import VAngle
-import angle_parser
-import rich_validator
-from target import ObservedTarget
-import frame
-from velocity import Velocity, ZERO_VELOCITY
+from . import valid_angles
+from .valid_angles import VAngle
+from . import angle_parser
+from . import rich_validator
+from .target import ObservedTarget
+from . import frame
+from .velocity import Velocity, ZERO_VELOCITY
 
 """
 string pattern identifying an option.

--- a/src/templates.py
+++ b/src/templates.py
@@ -23,6 +23,7 @@ Module containing templates (as defined in standard string module) used to trans
 representation used in the schedule files by ACS
 """
 
+from builtins import str
 import string
 import logging
 logger = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ def format_layout(name, conf):
     subscans = conf.pop("subscans", [])
     logger.debug("got subscans info %s" % (str(subscans),))
     #TODO: add subscans info in dat file
-    for k, v in conf.iteritems():
+    for k, v in conf.items():
         res += "\t%s=%s\n" % (str(k), str(v),)
     res += "}\n\n"
     return res

--- a/src/valid_angles.py
+++ b/src/valid_angles.py
@@ -43,7 +43,7 @@ CONSTANT. separator used in angle hour and sexagesimal representation
 
 class VAngle(Angle):
     def __new__(cls, angle, unit=u.deg, wrap_angle=360 * u.deg, **kwargs):
-        self = super(VAngle, cls).__new__(cls, angle, unit=unit, **kwargs)
+        self = Angle.__new__(cls, angle, unit=unit, **kwargs)
         self.original_unit = unit
         if unit == u.hour or isinstance(angle, tuple):
             self.sexa = True
@@ -52,10 +52,10 @@ class VAngle(Angle):
         return self
 
     def __init__(self, *args, **kwargs):
-        super(VAngle, self).__init__(*args, **kwargs)
+        Angle.__init__(*args, **kwargs)
 
     def __array_finalize__(self, obj):
-        super(VAngle, self).__array_finalize__(obj)
+        Angle.__array_finalize__(self, obj)
         if obj is None:return
         self.original_unit = getattr(obj, "original_unit", None)
         self.sexa = getattr(obj, "sexa", None)
@@ -83,7 +83,7 @@ class VAngle(Angle):
         """
         Return the sexagesimal string representation of the angle in hours
         """
-        _a_str = self.to_string(unit=u.hour, sep=SEXA_SEPARATOR, pad=True, 
+        _a_str = self.to_string(unit=u.hour, sep=SEXA_SEPARATOR, pad=True,
                               precision=ANGLE_DECIMALS)
         return _a_str + "h"
 

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -1,6 +1,10 @@
 #coding=utf-8
 
-import unittest2 as unittest
+from builtins import str
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import copy
 from io import StringIO
 
@@ -15,7 +19,7 @@ class TestRoachBackend(unittest.TestCase):
 
     def test_roach_backend_instructions(self):
         backend_instructions = ""
-        self.assertEqual(self.roach_backend._get_backend_instructions(), 
+        self.assertEqual(self.roach_backend._get_backend_instructions(),
                          backend_instructions)
 
     def test_roach_backend_bck_file(self):
@@ -34,7 +38,7 @@ class TestTotalPowerBackend(unittest.TestCase):
 
     def test_total_power_set_sections_enable(self):
         self.backend.set_sections(2)
-        instructions = StringIO(unicode(self.backend._get_backend_instructions()))
+        instructions = StringIO(str(self.backend._get_backend_instructions()))
         lines = instructions.readlines()
         enable_line = lines[-1].strip()
         self.assertTrue(enable_line.startswith("enable"))

--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import copy
 from astropy.coordinates import Angle
 from astropy import units as u

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import basie
 
 class TestInstallation(unittest.TestCase):
@@ -10,5 +13,6 @@ class TestInstallation(unittest.TestCase):
     def test_astropy_version(self):
         import astropy
         av = astropy.__version__.split('.')
-        self.assertEqual(av[0], '1')
+        assert int(av[0]) >= 1
+        # self.assertEqual(av[0], '1')
         #self.assertEqual(av[1], '0')

--- a/test/test_maps.py
+++ b/test/test_maps.py
@@ -1,6 +1,10 @@
 #coding=utf-8
-
-import unittest2 as unittest
+from __future__ import print_function, division
+from builtins import range
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie.frame import EQ, HOR
 from astropy.units import MHz
@@ -38,7 +42,7 @@ class TestMapScan(unittest.TestCase):
                                         self._scans_per_beam)
 
     def test_single_feed_fixed_spacing(self):
-        self._scan_fixed._get_spacing(self._srecv, [18 * MHz]) 
+        self._scan_fixed._get_spacing(self._srecv, [18 * MHz])
         scan_length_x = self._scan_fixed.offset_x[-1] - \
                         self._scan_fixed.offset_x[0]
         scan_length_y = self._scan_fixed.offset_y[-1] - \
@@ -46,16 +50,16 @@ class TestMapScan(unittest.TestCase):
         self.assertGreaterEqual(scan_length_x, self._length_x)
         self.assertGreaterEqual(scan_length_y, self._length_y)
         for i in range(len(self._scan_fixed.offset_x) - 1):
-            self.assertAlmostEqual(self._spacing.deg, 
+            self.assertAlmostEqual(self._spacing.deg,
                                    self._scan_fixed.offset_x[i+1].deg -\
-                                   self._scan_fixed.offset_x[i].deg) 
+                                   self._scan_fixed.offset_x[i].deg)
         for i in range(len(self._scan_fixed.offset_y) - 1):
-            self.assertAlmostEqual(self._spacing.deg, 
+            self.assertAlmostEqual(self._spacing.deg,
                                    self._scan_fixed.offset_y[i+1].deg -\
-                                   self._scan_fixed.offset_y[i].deg) 
+                                   self._scan_fixed.offset_y[i].deg)
 
     def test_multi_feed_fixed_spacing(self):
-        self._scan_fixed._get_spacing(self._recv, [18 * MHz]) 
+        self._scan_fixed._get_spacing(self._recv, [18 * MHz])
         scan_length_x = self._scan_fixed.offset_x[-1] - \
                         self._scan_fixed.offset_x[0]
         scan_length_y = self._scan_fixed.offset_y[-1] - \
@@ -64,7 +68,7 @@ class TestMapScan(unittest.TestCase):
         self.assertGreaterEqual(scan_length_y + self._recv.feed_extent * 2, self._length_y)
 
     def test_single_feed_dynamic_spacing(self):
-        self._scan_dynamic._get_spacing(self._srecv, [18 * MHz]) 
+        self._scan_dynamic._get_spacing(self._srecv, [18 * MHz])
         scan_length_x = self._scan_dynamic.offset_x[-1] - \
                         self._scan_dynamic.offset_x[0]
         scan_length_y = self._scan_dynamic.offset_y[-1] - \
@@ -74,7 +78,7 @@ class TestMapScan(unittest.TestCase):
 
     def test_multi_feed_dynamic_spacing(self):
         rec = self._recv
-        self._scan_dynamic._get_spacing(rec, [18 * MHz]) 
+        self._scan_dynamic._get_spacing(rec, [18 * MHz])
         scan_length_x = self._scan_dynamic.offset_x[-1] - \
                         self._scan_dynamic.offset_x[0]
         scan_length_y = self._scan_dynamic.offset_y[-1] - \
@@ -83,32 +87,32 @@ class TestMapScan(unittest.TestCase):
         self.assertGreaterEqual(scan_length_y + rec.feed_extent * 2, self._length_y)
         #check uniform sampling within receiver extent
         spb = int(rec.interleave / self._scan_dynamic.spacing)
-        for j in range(self._scan_dynamic.dimension_x / spb):
+        for j in range(self._scan_dynamic.dimension_x // spb):
             for i in range(spb - 2):
                 self.assertAlmostEqual(self._scan_dynamic.offset_x[j*spb + i+1].deg - \
-                                       self._scan_dynamic.offset_x[j*spb + i].deg, 
+                                       self._scan_dynamic.offset_x[j*spb + i].deg,
                                        self._scan_dynamic.offset_x[j*spb + i+2].deg - \
                                        self._scan_dynamic.offset_x[j*spb + i+1].deg,
                                        msg = "j: {0} i: {1}".format(j,i))
-        for j in range(self._scan_dynamic.dimension_y / spb):
+        for j in range(self._scan_dynamic.dimension_y // spb):
             for i in range(spb - 2):
                 self.assertAlmostEqual(self._scan_dynamic.offset_y[j*spb + i+1].deg - \
-                                       self._scan_dynamic.offset_y[j*spb + i].deg, 
+                                       self._scan_dynamic.offset_y[j*spb + i].deg,
                                        self._scan_dynamic.offset_y[j*spb + i+2].deg - \
                                        self._scan_dynamic.offset_y[j*spb + i+1].deg)
         #check uniform sampling accross receiver positions
-        for j in range(self._scan_dynamic.dimension_x / spb - 1):
+        for j in range(self._scan_dynamic.dimension_x // spb - 1):
             pre = j * spb
             fol = pre + spb
-            self.assertAlmostEqual(self._scan_dynamic.offset_x[fol].deg, 
+            self.assertAlmostEqual(self._scan_dynamic.offset_x[fol].deg,
                                    self._scan_dynamic.offset_x[pre].deg +\
                                    rec.feed_extent.deg * 2 +\
                                    rec.interleave.deg + \
                                    self._scan_dynamic.spacing.deg)
-        for j in range(self._scan_dynamic.dimension_y / spb - 1):
+        for j in range(self._scan_dynamic.dimension_y // spb - 1):
             pre = j * spb
             fol = pre + spb
-            self.assertAlmostEqual(self._scan_dynamic.offset_y[fol].deg, 
+            self.assertAlmostEqual(self._scan_dynamic.offset_y[fol].deg,
                                    self._scan_dynamic.offset_y[pre].deg +\
                                    rec.feed_extent.deg * 2 +\
                                    rec.interleave.deg + \

--- a/test/test_nodding.py
+++ b/test/test_nodding.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie.frame import EQ, HOR
 from astropy.units import MHz
@@ -28,5 +31,4 @@ class TestNoddingScan(unittest.TestCase):
    def test_nodding(self):
       self._nodding._do_scan(self.TARGET,self._recv,20.000)
       self.assertEqual(self._nodding.offset,-self._offset)
-    
-    
+

--- a/test/test_procedures.py
+++ b/test/test_procedures.py
@@ -1,6 +1,10 @@
 #coding=utf-8
 
-import unittest2 as unittest
+from builtins import str
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie.procedures import Procedure, PROC_PREFIX
 
@@ -41,7 +45,7 @@ class TestProcedures(unittest.TestCase):
         self.assertEqual(str(sum_procedure),
                          "%sSIMPLE_ONE_PARAM(1){\n\tnop\n\tparam=$1\n}\n" %
                          (PROC_PREFIX,))
- 
+
     def test_sum_simple_one_param_execution(self):
         # i want this to work eventually
         #sum_procedure = self.simple_procedure + \

--- a/test/test_receivers.py
+++ b/test/test_receivers.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie.radiotelescopes import SRT
 from basie.valid_angles import VAngle

--- a/test/test_rich_validator.py
+++ b/test/test_rich_validator.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 import basie.rich_validator as rv
 from basie import frame

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import os
 import shutil
 from basie import schedule

--- a/test/test_subscan.py
+++ b/test/test_subscan.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie import frame, target_parser
 from basie.scanmode import subscan

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie import target_parser
 from basie import frame
@@ -18,7 +21,7 @@ class TestTarget(unittest.TestCase):
         self.assertEqual(_target.repetitions, 3)
         self.assertEqual(_target.tsys, 4)
         self.assertEqual(_target.offset_coord, frame.Coord(frame.EQ, 0.0, 0.3))
-    
+
     def test_parse_file(self):
         targets = target_parser.parse_file(TARGETS_PATH)
         self.assertNotEqual(targets, [])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie import utils
 from basie.valid_angles import VAngle

--- a/test/test_valid_angles.py
+++ b/test/test_valid_angles.py
@@ -1,4 +1,7 @@
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie.valid_angles import VAngle
 from basie import angle_parser
@@ -18,7 +21,7 @@ class TestAngles(unittest.TestCase):
 
     def test_parsing_hour(self):
         ang = angle_parser.check_hms_angle("01:00:00.0h")
-        self.assertAlmostEqual(ang.deg, VAngle(15.0).deg) 
+        self.assertAlmostEqual(ang.deg, VAngle(15.0).deg)
 
     def test_parsing_dec(self):
         ang = angle_parser.check_dec_angle("15.0d")

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,6 +1,9 @@
 #coding=utf-8
 
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from basie.rich_validator import *
 from basie.valid_angles import VAngle


### PR DESCRIPTION
*Lots* of changes.
All tests pass on Python 2.7 and 3.6 on my machine. Is 2.6 compatibility a must-have?

+ Usual stuff like print function and division 
+ Calling the parent class instead of `super()` (it works differently in 2 and 3)
+ configobj now called from astropy.extern (it's there and works on Py2 and 3, why not eliminate a dependency)
+ Use the `future` package to make some Py3 functionality available in Py2

etc.
Hope this works!