### PR TITLE
Fix #61, implemented the ELEVATIONLIMITS keyword

### DIFF
--- a/basie/schedule.py
+++ b/basie/schedule.py
@@ -55,6 +55,8 @@ class Schedule(Persistent):
                  receiver = "C", #should we change this?
                  outputFormat = "fits",
                  ftrack = False,
+                 minElevation = -1,
+                 maxElevation = -1,
                  ):
         logger.debug("creating schedule")
         self.projectID = projectID
@@ -65,6 +67,8 @@ class Schedule(Persistent):
         self.runs = scheduleRuns
         self.scantypes = {}
         self.backends = {}
+        self.minElevation = float(minElevation)
+        self.maxElevation = float(maxElevation)
         self.radiotelescope = radiotelescopes[radiotelescope]
         if not receiver in list(self.radiotelescope.receivers.keys()):
             raise ScheduleError("receiver does not belong to telescope")
@@ -196,15 +200,21 @@ class Schedule(Persistent):
             rst_procedure = procedures.Procedure("restFrequency", 0,
                     "\trestFrequency=%s\n" % freqstring, True)
             init_procedure = init_procedure + rst_procedure
-        scdfile.write(templates.scd_header.substitute(
-                              dict(
-                                projectID = self.projectID,
-                                observer = self.observer,
-                                lisfilename = os.path.basename(lisfilename),
-                                cfgfilename = os.path.basename(cfgfilename),
-                                bckfilename = os.path.basename(bckfilename),
-                                initproc = init_procedure.execute(),
-                                  )))
+        scdfile.write(templates.scd_header.substitute(dict(
+            projectID = self.projectID,
+            observer = self.observer,
+            lisfilename = os.path.basename(lisfilename),
+            cfgfilename = os.path.basename(cfgfilename),
+            bckfilename = os.path.basename(bckfilename),
+            initproc = init_procedure.execute(),
+            minElevation = self.minElevation,
+            maxElevation = self.maxElevation,
+        )))
+        if self.minElevation != -1 or self.maxElevation != -1:
+            scdfile.write(templates.elevation_limits.substitute(dict(
+                minElevation = self.minElevation,
+                maxElevation = self.maxElevation,
+            )))
 
         #WRITE SCAN AND SUBSCANS INFORMATIONS SEQUENTIALLY
         scan_number = 1

--- a/basie/templates.py
+++ b/basie/templates.py
@@ -28,18 +28,19 @@ import string
 import logging
 logger = logging.getLogger(__name__)
 
-scd_header = string.Template("PROJECT:\t${projectID}\n" +
-                             "OBSERVER:\t${observer}\n" +
-                             "SCANLIST:\t${lisfilename}\n" +
-                             "PROCEDURELIST:\t${cfgfilename}\n" +
-                             "BACKENDLIST:\t${bckfilename}\n" +
-                             "MODE:\tSEQ\n" +
-                             "SCANTAG:\t1\n" +
-                             "INITPROC:\t${initproc}\n")
+scd_header = string.Template("PROJECT:\t\t${projectID}\n" +
+                             "OBSERVER:\t\t${observer}\n" +
+                             "SCANLIST:\t\t${lisfilename}\n" +
+                             "PROCEDURELIST:\t\t${cfgfilename}\n" +
+                             "BACKENDLIST:\t\t${bckfilename}\n" +
+                             "MODE:\t\t\tSEQ\n" +
+                             "SCANTAG:\t\t1\n" +
+                             "INITPROC:\t\t${initproc}\n")
 """
 Used to convert a L{schedule.Schedule} instance into its representation in the .scd
 file header
 """
+elevation_limits = string.Template("ELEVATIONLIMITS:\t${minElevation}\t${maxElevation}\n")
 
 scd_scanlayout = string.Template("SCANLAYOUT:\t${datfilename}\n")
 

--- a/basie/user_templates/configuration.txt
+++ b/basie/user_templates/configuration.txt
@@ -18,6 +18,10 @@ tsys = 0
 #restFrequency = 22345.18,22410.10
 #restFrequency = 22000
 #ftrack = True
+#optional minElevation in degrees
+#minElevation = 6
+#optional maxElevation in degrees
+#maxElevation = 87
 
 # File name of the target specs in this same directory
 targetsFile =  targets.txt


### PR DESCRIPTION
The `configuration.txt` template now mentions `minElevation` and `maxElevation` keywords that are finally combined into `ELEVATIONLIMITS` when the `basie` command is executed with a valid `configuration.txt` file. The documentation of this repository is automatically generated, the user manual is a bit outdated, maybe we should think about updating it with all the new features (this one as well as the nodding one, etc).